### PR TITLE
Streamline deployment process by using kubectl for rollout

### DIFF
--- a/.github/workflows/CICD Microservices.yaml
+++ b/.github/workflows/CICD Microservices.yaml
@@ -36,20 +36,6 @@ jobs:
     runs-on: self-hosted
     needs: build-and-push
     steps:
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: rsantamaria01
-          password: ${{ secrets.GHCR_PASSWORD }}
-
       - name: Pull and Deploy Microservices
         run: |
-          echo "Navigating to directory: ${{secrets.PATH_DOCKER_COMPOSE}}"
-          cd ${{secrets.PATH_DOCKER_COMPOSE}}
-          
-          echo "Pulling the latest image for ${{vars.MICROSERVICE_NAME}}..."
-          docker pull ghcr.io/hsm-sanosoft/${{vars.MICROSERVICE_NAME}}:latest
-
-          echo "Restarting ${{vars.MICROSERVICE_NAME}} container..."
-          docker-compose -f docker-compose.prod.yml up -d --no-deps ${{vars.MICROSERVICE_NAME}}
+          kubectl rollout restart deployment ${{vars.MICROSERVICE_NAME}} -n app


### PR DESCRIPTION
Remove Docker login and pull steps to simplify the deployment process, replacing them with a kubectl command for restarting the deployment.